### PR TITLE
feat: implement GitHub App-based repository claiming flow

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -19,6 +19,14 @@ GITHUB_CLIENT_ID="your-github-dev-client-id"
 GITHUB_CLIENT_SECRET="your-github-dev-client-secret"
 GITHUB_TOKEN="your-github-token"
 
+# GitHub App (Repo Claiming)
+# Create at: https://github.com/settings/apps
+# Setup URL: https://usegrip.xyz/api/github/callback (proxies to localhost for dev)
+GITHUB_APP_ID="your-github-app-id"
+GITHUB_APP_SLUG="your-github-app-slug"
+GITHUB_APP_WEBHOOK_SECRET="your-github-app-webhook-secret"
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nyour-private-key-here\n-----END RSA PRIVATE KEY-----"
+
 # WebAuthn / Passkey
 NEXT_PUBLIC_RP_ID="localhost"
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/app/(main)/[owner]/[repo]/_components/repo-stats-card.tsx
+++ b/app/(main)/[owner]/[repo]/_components/repo-stats-card.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import { TokenAmount } from '@/components/tempo/token-amount';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Plus } from 'lucide-react';
 import Link from 'next/link';
+import { useState } from 'react';
 
 interface RepoStatsCardProps {
   owner: string;
@@ -25,13 +28,26 @@ export function RepoStatsCard({
   canManage,
   isLoggedIn,
 }: RepoStatsCardProps) {
+  const [claiming, setClaiming] = useState(false);
+
+  async function handleClaim() {
+    setClaiming(true);
+    try {
+      const res = await fetch(`/api/repos/${owner}/${repo}/claim`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error);
+      window.location.href = data.installUrl;
+    } catch {
+      setClaiming(false);
+    }
+  }
   return (
     <Card className="rounded-xl">
       <CardContent className="p-6">
         <div className="divide-y divide-border">
           <div className="flex items-baseline justify-between py-4 first:pt-0">
             <div className="flex flex-col">
-              <span className="text-2xl font-bold text-emerald-600">
+              <span className="text-2xl font-bold text-primary">
                 <TokenAmount amount={totalFunded} symbol="" />
               </span>
               <span className="text-sm text-muted-foreground mt-1">USDC Funded</span>
@@ -40,14 +56,14 @@ export function RepoStatsCard({
 
           <div className="flex items-baseline justify-between py-4">
             <div className="flex flex-col">
-              <span className="text-3xl font-bold text-amber-500">{openBounties}</span>
+              <span className="text-3xl font-bold text-chart-4">{openBounties}</span>
               <span className="text-sm text-muted-foreground mt-1">Open Bounties</span>
             </div>
           </div>
 
           <div className="flex items-baseline justify-between py-4 last:pb-0">
             <div className="flex flex-col">
-              <span className="text-3xl font-bold text-slate-400">{completedBounties}</span>
+              <span className="text-3xl font-bold text-muted-foreground">{completedBounties}</span>
               <span className="text-sm text-muted-foreground mt-1">Completed</span>
             </div>
           </div>
@@ -61,7 +77,7 @@ export function RepoStatsCard({
                 Create Bounty
               </Link>
             }
-            className="w-full mt-4 bg-slate-900 hover:bg-slate-800"
+            className="w-full mt-4"
           />
         )}
 
@@ -71,12 +87,14 @@ export function RepoStatsCard({
               {!isClaimed ? (
                 <>
                   Maintainer?{' '}
-                  <Link
-                    href={`/${owner}/${repo}/settings`}
-                    className="text-primary font-medium hover:underline"
+                  <button
+                    type="button"
+                    onClick={handleClaim}
+                    disabled={claiming}
+                    className="text-primary font-medium hover:underline disabled:opacity-50"
                   >
-                    Claim this repo
-                  </Link>
+                    {claiming ? 'Redirecting...' : 'Claim this repo'}
+                  </button>
                 </>
               ) : (
                 <Link

--- a/app/(main)/[owner]/[repo]/settings/_components/claim-result-banner.tsx
+++ b/app/(main)/[owner]/[repo]/settings/_components/claim-result-banner.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+interface ClaimResultBannerProps {
+  claimed?: boolean;
+  error?: string;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  invalid_state: 'The claim link expired or was invalid. Please try again.',
+  missing_state: 'Missing authentication state. Please try again.',
+  repo_not_in_installation:
+    'The repository was not included in the GitHub App installation. Please try again and select this repository.',
+  repo_not_found: 'Repository not found on GitHub.',
+  session_expired: 'Your session expired. Please log in again.',
+  database_error: 'Failed to save repository settings. Please try again.',
+  github_api_error: 'Failed to communicate with GitHub. Please try again.',
+  installation_cancelled: 'GitHub App installation was cancelled.',
+};
+
+/**
+ * Claim Result Banner
+ *
+ * Shows success or error message after the claim flow completes.
+ * Auto-cleans the URL after displaying the message.
+ */
+export function ClaimResultBanner({ claimed, error }: ClaimResultBannerProps) {
+  const router = useRouter();
+
+  // Clean up URL after showing the message
+  useEffect(() => {
+    if (claimed || error) {
+      const timer = setTimeout(() => {
+        router.replace(window.location.pathname);
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [claimed, error, router]);
+
+  if (claimed) {
+    return (
+      <div className="mb-6 rounded-lg border border-success/30 bg-success/10 p-4">
+        <p className="font-medium text-success">Repository claimed successfully!</p>
+        <p className="mt-1 text-sm text-success/80">
+          You now have full access to repository settings and webhook integration.
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    const message = ERROR_MESSAGES[error] || `An error occurred: ${error}`;
+    return (
+      <div className="mb-6 rounded-lg border border-destructive/30 bg-destructive/10 p-4">
+        <p className="font-medium text-destructive">Failed to claim repository</p>
+        <p className="mt-1 text-sm text-destructive/80">{message}</p>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/app/(main)/[owner]/[repo]/settings/page.tsx
+++ b/app/(main)/[owner]/[repo]/settings/page.tsx
@@ -2,11 +2,13 @@ import { Button } from '@/components/ui/button';
 import { getRepoSettingsByName, isUserRepoOwner } from '@/db/queries/repo-settings';
 import { getSession } from '@/lib/auth/auth-server';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
+import { ClaimRepoCard } from '../_components/claim-repo-card';
+import { ClaimResultBanner } from './_components/claim-result-banner';
 import { SettingsLayout } from './_components/settings-layout';
 
 interface SettingsPageProps {
   params: Promise<{ owner: string; repo: string }>;
+  searchParams: Promise<{ claimed?: string; error?: string }>;
 }
 
 /**
@@ -18,26 +20,59 @@ interface SettingsPageProps {
  * - Treasury: Wallet setup and balance (owner's wallet)
  * - Webhooks: GitHub webhook configuration
  */
-export default async function SettingsPage({ params }: SettingsPageProps) {
+export default async function SettingsPage({ params, searchParams }: SettingsPageProps) {
   const { owner, repo } = await params;
+  const { claimed, error } = await searchParams;
 
-  // Check authentication
+  // Get session first (don't redirect yet - we may show claim UI)
   const session = await getSession();
-  if (!session?.user) {
-    redirect(`/login?callbackUrl=/${owner}/${repo}/settings`);
-  }
 
   // Get repo settings
   const repoSettings = await getRepoSettingsByName(owner, repo);
+
+  // If repo not claimed, show claim flow
   if (!repoSettings) {
+    // Not logged in - prompt to sign in first
+    if (!session?.user) {
+      return (
+        <div className="container py-8 text-center">
+          <h1 className="text-2xl font-bold">Claim this repository</h1>
+          <p className="mt-2 text-muted-foreground">
+            Sign in to claim {owner}/{repo} and unlock maintainer features.
+          </p>
+          <Button
+            nativeButton={false}
+            render={<Link href={`/login?callbackUrl=/${owner}/${repo}/settings`} />}
+            className="mt-4"
+          >
+            Sign in to claim
+          </Button>
+        </div>
+      );
+    }
+
+    // Logged in - show claim card
+    return (
+      <div className="container py-8 max-w-2xl mx-auto">
+        <ClaimRepoCard owner={owner} repo={repo} />
+      </div>
+    );
+  }
+
+  // Repo is claimed - require auth from here on
+  if (!session?.user) {
     return (
       <div className="container py-8 text-center">
-        <h1 className="text-2xl font-bold">Repo Settings not found</h1>
+        <h1 className="text-2xl font-bold">Sign in required</h1>
         <p className="mt-2 text-muted-foreground">
-          No settings found for {owner}/{repo}
+          Sign in to access settings for {owner}/{repo}
         </p>
-        <Button nativeButton={false} render={<Link href="/explore" />} className="mt-4">
-          Browse Bounties
+        <Button
+          nativeButton={false}
+          render={<Link href={`/login?callbackUrl=/${owner}/${repo}/settings`} />}
+          className="mt-4"
+        >
+          Sign in
         </Button>
       </div>
     );
@@ -63,6 +98,7 @@ export default async function SettingsPage({ params }: SettingsPageProps) {
 
   return (
     <div className="container py-8">
+      <ClaimResultBanner claimed={claimed === 'true'} error={error} />
       <SettingsLayout githubRepoId={Number(repoSettings.githubRepoId)} owner={owner} repo={repo} />
     </div>
   );

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -1,0 +1,136 @@
+import {
+  createRepoSettings,
+  getRepoSettingsByName,
+  updateRepoInstallation,
+} from '@/db/queries/repo-settings';
+import { getSession } from '@/lib/auth/auth-server';
+import { fetchGitHubRepo, getInstallationRepos, verifyClaimState } from '@/lib/github';
+import { redirect } from 'next/navigation';
+import type { NextRequest } from 'next/server';
+
+/**
+ * GET /api/github/callback
+ *
+ * Handle the callback from GitHub after App installation.
+ * Verifies the state parameter and creates/updates repo_settings.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+
+  const installationId = searchParams.get('installation_id');
+  const state = searchParams.get('state');
+  const setupAction = searchParams.get('setup_action');
+
+  // Handle case where user cancelled or there's no installation
+  if (!installationId) {
+    console.log('[github-callback] No installation_id, user likely cancelled');
+    return redirect('/?error=installation_cancelled');
+  }
+
+  // Verify state parameter
+  if (!state) {
+    console.log('[github-callback] Missing state parameter');
+    return redirect('/?error=missing_state');
+  }
+
+  const claimState = verifyClaimState(state);
+  if (!claimState) {
+    console.log('[github-callback] Invalid or expired state');
+    return redirect('/?error=invalid_state');
+  }
+
+  // Dev proxy: redirect to localhost if callback originated from dev environment
+  // Security: Only proxy to localhost/127.0.0.1, only when running on production
+  if (claimState.callbackUrl) {
+    const currentHostname = new URL(request.url).hostname;
+    const isProduction = currentHostname === 'usegrip.xyz' || currentHostname === 'www.usegrip.xyz';
+
+    // Allowlist of dev hosts
+    const DEV_HOSTS = ['localhost', '127.0.0.1'];
+    let isDevTarget = false;
+    try {
+      const targetHostname = new URL(claimState.callbackUrl).hostname;
+      isDevTarget = DEV_HOSTS.includes(targetHostname);
+    } catch {
+      isDevTarget = false;
+    }
+
+    if (isProduction && isDevTarget) {
+      // Proxy to dev callback URL with same params
+      const proxyUrl = new URL(claimState.callbackUrl);
+      proxyUrl.searchParams.set('installation_id', installationId);
+      proxyUrl.searchParams.set('state', state);
+      if (setupAction) {
+        proxyUrl.searchParams.set('setup_action', setupAction);
+      }
+
+      console.log(`[github-callback] Proxying to dev: ${proxyUrl.origin}`);
+      return redirect(proxyUrl.toString());
+    }
+
+    // Log warning if non-dev callbackUrl (potential attack attempt)
+    if (!isDevTarget) {
+      console.warn(`[github-callback] Ignoring non-dev callbackUrl: ${claimState.callbackUrl}`);
+    }
+  }
+
+  // Verify user session matches state
+  const session = await getSession();
+  if (!session?.user || session.user.id !== claimState.userId) {
+    console.log('[github-callback] Session mismatch or expired');
+    return redirect(
+      `/login?error=session_expired&next=${encodeURIComponent(`/${claimState.owner}/${claimState.repo}`)}`
+    );
+  }
+
+  // Verify the target repo is in the installation
+  let repos: Awaited<ReturnType<typeof getInstallationRepos>>;
+  try {
+    repos = await getInstallationRepos(installationId);
+  } catch (error) {
+    console.error('[github-callback] Failed to fetch installation repos:', error);
+    return redirect(`/${claimState.owner}/${claimState.repo}?error=github_api_error`);
+  }
+
+  const targetFullName = `${claimState.owner}/${claimState.repo}`;
+  const targetRepo = repos.find((r) => r.full_name.toLowerCase() === targetFullName.toLowerCase());
+
+  if (!targetRepo) {
+    console.log(`[github-callback] Repo ${targetFullName} not in installation`);
+    return redirect(`/${claimState.owner}/${claimState.repo}?error=repo_not_in_installation`);
+  }
+
+  // Get GitHub repo details for the ID
+  const githubRepo = await fetchGitHubRepo(claimState.owner, claimState.repo);
+  if (!githubRepo) {
+    console.log(`[github-callback] Repo ${targetFullName} not found on GitHub`);
+    return redirect(`/${claimState.owner}/${claimState.repo}?error=repo_not_found`);
+  }
+
+  // Create or update repo_settings
+  try {
+    const existing = await getRepoSettingsByName(claimState.owner, claimState.repo);
+
+    if (existing) {
+      // Update existing record
+      await updateRepoInstallation(existing.githubRepoId, installationId, session.user.id);
+      console.log(`[github-callback] Updated repo_settings for ${targetFullName}`);
+    } else {
+      // Create new record
+      await createRepoSettings({
+        verifiedOwnerUserId: session.user.id,
+        githubRepoId: BigInt(githubRepo.id),
+        githubOwner: claimState.owner,
+        githubRepo: claimState.repo,
+        installationId: BigInt(installationId),
+      });
+      console.log(`[github-callback] Created repo_settings for ${targetFullName}`);
+    }
+  } catch (error) {
+    console.error('[github-callback] Failed to create/update repo_settings:', error);
+    return redirect(`/${claimState.owner}/${claimState.repo}?error=database_error`);
+  }
+
+  // Success - redirect to settings page
+  return redirect(`/${claimState.owner}/${claimState.repo}/settings?claimed=true`);
+}

--- a/app/api/repos/[owner]/[repo]/claim/route.ts
+++ b/app/api/repos/[owner]/[repo]/claim/route.ts
@@ -1,0 +1,56 @@
+import { requireAuth } from '@/lib/auth/auth-server';
+import { fetchGitHubRepo, signClaimState, getSimpleInstallUrl } from '@/lib/github';
+import { type NextRequest, NextResponse } from 'next/server';
+
+interface RouteParams {
+  params: Promise<{ owner: string; repo: string }>;
+}
+
+/**
+ * POST /api/repos/[owner]/[repo]/claim
+ *
+ * Initiate the repo claiming flow by generating a signed state
+ * and returning the GitHub App installation URL.
+ */
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await requireAuth();
+    const { owner, repo } = await params;
+
+    // Verify repo exists on GitHub
+    const githubRepo = await fetchGitHubRepo(owner, repo);
+    if (!githubRepo) {
+      return NextResponse.json({ error: 'Repository not found on GitHub' }, { status: 404 });
+    }
+
+    // Only allow claiming public repos
+    if (githubRepo.private) {
+      return NextResponse.json({ error: 'Cannot claim private repositories' }, { status: 400 });
+    }
+
+    // Include callbackUrl in state if not production (enables dev proxy)
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const productionUrl = 'https://usegrip.xyz';
+    const callbackUrl = appUrl !== productionUrl ? `${appUrl}/api/github/callback` : undefined;
+
+    // Generate signed state for the installation callback
+    const state = signClaimState({
+      userId: session.user.id,
+      owner: githubRepo.owner.login,
+      repo: githubRepo.name,
+      timestamp: Date.now(),
+      callbackUrl,
+    });
+
+    // Build the GitHub App installation URL
+    const installUrl = getSimpleInstallUrl(state);
+
+    return NextResponse.json({ installUrl });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    console.error('[claim] Error initiating claim:', error);
+    return NextResponse.json({ error: 'Failed to initiate claim' }, { status: 500 });
+  }
+}

--- a/db/schema/business.ts
+++ b/db/schema/business.ts
@@ -188,9 +188,12 @@ export const repoSettings = pgTable(
     }),
     verifiedAt: timestamp('verified_at', { mode: 'string' }),
 
-    // GitHub webhook (optional)
+    // GitHub webhook (optional, legacy per-repo webhooks)
     webhookId: i64('webhook_id'),
     webhookSecret: text('webhook_secret'),
+
+    // GitHub App installation (for claimed repos)
+    installationId: i64('installation_id'),
 
     createdAt: timestamp('created_at', { mode: 'string' }).defaultNow(),
     updatedAt: timestamp('updated_at', { mode: 'string' })
@@ -200,6 +203,7 @@ export const repoSettings = pgTable(
   (table) => ({
     idxRepoSettingsOwner: index('idx_repo_settings_owner').on(table.verifiedOwnerUserId),
     idxRepoSettingsName: index('idx_repo_settings_name').on(table.githubOwner, table.githubRepo),
+    idxRepoSettingsInstallation: index('idx_repo_settings_installation').on(table.installationId),
   })
 );
 

--- a/drizzle/0019_romantic_blazing_skull.sql
+++ b/drizzle/0019_romantic_blazing_skull.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "repo_settings" ADD COLUMN "installation_id" bigint;--> statement-breakpoint
+CREATE INDEX "idx_repo_settings_installation" ON "repo_settings" USING btree ("installation_id");

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,3191 @@
+{
+  "id": "3eaf34b6-078c-47ef-8310-c1ad0aeec5f5",
+  "prevId": "b51f19ea-8dcd-4db2-a58f-8c69a0dd6ff5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'manual_invite'"
+        },
+        "github_org_role": {
+          "name": "github_org_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_org_id": {
+          "name": "github_org_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_org_login": {
+          "name": "github_org_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_membership": {
+          "name": "sync_membership",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organization_github_org_id_unique": {
+          "name": "organization_github_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["github_org_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tempo_address": {
+          "name": "tempo_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_tempo_address_unique": {
+          "name": "passkey_tempo_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tempo_address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_github_user_id_unique": {
+          "name": "user_github_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["github_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.access_keys": {
+      "name": "access_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backend_wallet_address": {
+          "name": "backend_wallet_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_user_passkey_id": {
+          "name": "authorized_user_passkey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_type": {
+          "name": "key_type",
+          "type": "access_key_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secp256k1'"
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limits": {
+          "name": "limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "authorization_signature": {
+          "name": "authorization_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_hash": {
+          "name": "authorization_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_dedicated": {
+          "name": "is_dedicated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_keys_user": {
+          "name": "idx_access_keys_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_keys_org": {
+          "name": "idx_access_keys_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_keys_authorized_user": {
+          "name": "idx_access_keys_authorized_user",
+          "columns": [
+            {
+              "expression": "authorized_user_passkey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_keys_status": {
+          "name": "idx_access_keys_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_keys_backend_wallet": {
+          "name": "idx_access_keys_backend_wallet",
+          "columns": [
+            {
+              "expression": "backend_wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_keys_user_id_user_id_fk": {
+          "name": "access_keys_user_id_user_id_fk",
+          "tableFrom": "access_keys",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_keys_organization_id_organization_id_fk": {
+          "name": "access_keys_organization_id_organization_id_fk",
+          "tableFrom": "access_keys",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_keys_authorized_user_passkey_id_passkey_id_fk": {
+          "name": "access_keys_authorized_user_passkey_id_passkey_id_fk",
+          "tableFrom": "access_keys",
+          "tableTo": "passkey",
+          "columnsFrom": ["authorized_user_passkey_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_access_keys_unique_active": {
+          "name": "idx_access_keys_unique_active",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "backend_wallet_address", "network"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_settings_id": {
+          "name": "repo_settings_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounty_id": {
+          "name": "bounty_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payout_id": {
+          "name": "payout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_event_type": {
+          "name": "idx_activity_log_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_network": {
+          "name": "idx_activity_log_network",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_user": {
+          "name": "idx_activity_log_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_user_id_fk": {
+          "name": "activity_log_user_id_user_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_repo_settings_id_repo_settings_github_repo_id_fk": {
+          "name": "activity_log_repo_settings_id_repo_settings_github_repo_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "repo_settings",
+          "columnsFrom": ["repo_settings_id"],
+          "columnsTo": ["github_repo_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_bounty_id_bounties_id_fk": {
+          "name": "activity_log_bounty_id_bounties_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "bounties",
+          "columnsFrom": ["bounty_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_submission_id_submissions_id_fk": {
+          "name": "activity_log_submission_id_submissions_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "submissions",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_payout_id_payouts_id_fk": {
+          "name": "activity_log_payout_id_payouts_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "payouts",
+          "columnsFrom": ["payout_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bounties": {
+      "name": "bounties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_settings_id": {
+          "name": "repo_settings_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_full_name": {
+          "name": "github_full_name",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_issue_number": {
+          "name": "github_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_issue_id": {
+          "name": "github_issue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_issue_author_id": {
+          "name": "github_issue_author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "total_funded": {
+          "name": "total_funded",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_funder_id": {
+          "name": "primary_funder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_approved_at": {
+          "name": "owner_approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bounties_network_status": {
+          "name": "idx_bounties_network_status",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bounties_network_repo": {
+          "name": "idx_bounties_network_repo",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bounties_primary_funder": {
+          "name": "idx_bounties_primary_funder",
+          "columns": [
+            {
+              "expression": "primary_funder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bounties_repo_settings": {
+          "name": "idx_bounties_repo_settings",
+          "columns": [
+            {
+              "expression": "repo_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bounties_org": {
+          "name": "idx_bounties_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bounties_repo_settings_id_repo_settings_github_repo_id_fk": {
+          "name": "bounties_repo_settings_id_repo_settings_github_repo_id_fk",
+          "tableFrom": "bounties",
+          "tableTo": "repo_settings",
+          "columnsFrom": ["repo_settings_id"],
+          "columnsTo": ["github_repo_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bounties_primary_funder_id_user_id_fk": {
+          "name": "bounties_primary_funder_id_user_id_fk",
+          "tableFrom": "bounties",
+          "tableTo": "user",
+          "columnsFrom": ["primary_funder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bounties_organization_id_organization_id_fk": {
+          "name": "bounties_organization_id_organization_id_fk",
+          "tableFrom": "bounties",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bounties_token_address_network_tokens_address_network_fk": {
+          "name": "bounties_token_address_network_tokens_address_network_fk",
+          "tableFrom": "bounties",
+          "tableTo": "tokens",
+          "columnsFrom": ["token_address", "network"],
+          "columnsTo": ["address", "network"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_bounties_unique_issue": {
+          "name": "idx_bounties_unique_issue",
+          "nullsNotDistinct": false,
+          "columns": ["network", "github_issue_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bounty_funders": {
+      "name": "bounty_funders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bounty_id": {
+          "name": "bounty_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "funder_id": {
+          "name": "funder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_bounty_funders_bounty": {
+          "name": "idx_bounty_funders_bounty",
+          "columns": [
+            {
+              "expression": "bounty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bounty_funders_funder": {
+          "name": "idx_bounty_funders_funder",
+          "columns": [
+            {
+              "expression": "funder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bounty_funders_org": {
+          "name": "idx_bounty_funders_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bounty_funders_network": {
+          "name": "idx_bounty_funders_network",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bounty_funders_bounty_id_bounties_id_fk": {
+          "name": "bounty_funders_bounty_id_bounties_id_fk",
+          "tableFrom": "bounty_funders",
+          "tableTo": "bounties",
+          "columnsFrom": ["bounty_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bounty_funders_funder_id_user_id_fk": {
+          "name": "bounty_funders_funder_id_user_id_fk",
+          "tableFrom": "bounty_funders",
+          "tableTo": "user",
+          "columnsFrom": ["funder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bounty_funders_organization_id_organization_id_fk": {
+          "name": "bounty_funders_organization_id_organization_id_fk",
+          "tableFrom": "bounty_funders",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bounty_funders_token_address_network_tokens_address_network_fk": {
+          "name": "bounty_funders_token_address_network_tokens_address_network_fk",
+          "tableFrom": "bounty_funders",
+          "tableTo": "tokens",
+          "columnsFrom": ["token_address", "network"],
+          "columnsTo": ["address", "network"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bounty_funders_bounty_id_funder_id_unique": {
+          "name": "bounty_funders_bounty_id_funder_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["bounty_id", "funder_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_bounty_funded": {
+          "name": "email_bounty_funded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_submission_received": {
+          "name": "email_submission_received",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_bounty_completed": {
+          "name": "email_bounty_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_payout_received": {
+          "name": "email_payout_received",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_weekly_digest": {
+          "name": "email_weekly_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_timezone": {
+          "name": "quiet_hours_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user": {
+          "name": "idx_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_unread": {
+          "name": "idx_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payouts": {
+      "name": "payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounty'"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounty_id": {
+          "name": "bounty_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_settings_id": {
+          "name": "repo_settings_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer_user_id": {
+          "name": "payer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer_organization_id": {
+          "name": "payer_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_passkey_id": {
+          "name": "recipient_passkey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo_issue_number": {
+          "name": "memo_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo_pr_number": {
+          "name": "memo_pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo_contributor": {
+          "name": "memo_contributor",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo_bytes32": {
+          "name": "memo_bytes32",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo_message": {
+          "name": "memo_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_receipt_hash": {
+          "name": "work_receipt_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_receipt_locator": {
+          "name": "work_receipt_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custodial_wallet_id": {
+          "name": "custodial_wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custodial": {
+          "name": "is_custodial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payouts_network_user": {
+          "name": "idx_payouts_network_user",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_network_status": {
+          "name": "idx_payouts_network_status",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_submission": {
+          "name": "idx_payouts_submission",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_tx_hash": {
+          "name": "idx_payouts_tx_hash",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_custodial": {
+          "name": "idx_payouts_custodial",
+          "columns": [
+            {
+              "expression": "custodial_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_payment_type": {
+          "name": "idx_payouts_payment_type",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_sender": {
+          "name": "idx_payouts_sender",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payer_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_payer_org": {
+          "name": "idx_payouts_payer_org",
+          "columns": [
+            {
+              "expression": "payer_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payouts_submission_id_submissions_id_fk": {
+          "name": "payouts_submission_id_submissions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "submissions",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payouts_bounty_id_bounties_id_fk": {
+          "name": "payouts_bounty_id_bounties_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "bounties",
+          "columnsFrom": ["bounty_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payouts_repo_settings_id_repo_settings_github_repo_id_fk": {
+          "name": "payouts_repo_settings_id_repo_settings_github_repo_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "repo_settings",
+          "columnsFrom": ["repo_settings_id"],
+          "columnsTo": ["github_repo_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payouts_payer_user_id_user_id_fk": {
+          "name": "payouts_payer_user_id_user_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "user",
+          "columnsFrom": ["payer_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payouts_payer_organization_id_organization_id_fk": {
+          "name": "payouts_payer_organization_id_organization_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "organization",
+          "columnsFrom": ["payer_organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payouts_recipient_user_id_user_id_fk": {
+          "name": "payouts_recipient_user_id_user_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "user",
+          "columnsFrom": ["recipient_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payouts_recipient_passkey_id_passkey_id_fk": {
+          "name": "payouts_recipient_passkey_id_passkey_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "passkey",
+          "columnsFrom": ["recipient_passkey_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payouts_token_address_network_tokens_address_network_fk": {
+          "name": "payouts_token_address_network_tokens_address_network_fk",
+          "tableFrom": "payouts",
+          "tableTo": "tokens",
+          "columnsFrom": ["token_address", "network"],
+          "columnsTo": ["address", "network"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_payments": {
+      "name": "pending_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounty_id": {
+          "name": "bounty_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funder_id": {
+          "name": "funder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_github_user_id": {
+          "name": "recipient_github_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_github_username": {
+          "name": "recipient_github_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedicated_access_key_id": {
+          "name": "dedicated_access_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payout_id": {
+          "name": "payout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_payments_github_user": {
+          "name": "idx_pending_payments_github_user",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payments_funder": {
+          "name": "idx_pending_payments_funder",
+          "columns": [
+            {
+              "expression": "funder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payments_org": {
+          "name": "idx_pending_payments_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payments_claim_token": {
+          "name": "idx_pending_payments_claim_token",
+          "columns": [
+            {
+              "expression": "claim_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_payments_bounty_id_bounties_id_fk": {
+          "name": "pending_payments_bounty_id_bounties_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "bounties",
+          "columnsFrom": ["bounty_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payments_submission_id_submissions_id_fk": {
+          "name": "pending_payments_submission_id_submissions_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "submissions",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payments_funder_id_user_id_fk": {
+          "name": "pending_payments_funder_id_user_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "user",
+          "columnsFrom": ["funder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_payments_organization_id_organization_id_fk": {
+          "name": "pending_payments_organization_id_organization_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payments_dedicated_access_key_id_access_keys_id_fk": {
+          "name": "pending_payments_dedicated_access_key_id_access_keys_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "access_keys",
+          "columnsFrom": ["dedicated_access_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_payments_approved_by_user_id_user_id_fk": {
+          "name": "pending_payments_approved_by_user_id_user_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "user",
+          "columnsFrom": ["approved_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_payments_claimed_by_user_id_user_id_fk": {
+          "name": "pending_payments_claimed_by_user_id_user_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_payments_payout_id_payouts_id_fk": {
+          "name": "pending_payments_payout_id_payouts_id_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "payouts",
+          "columnsFrom": ["payout_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_payments_token_address_network_tokens_address_network_fk": {
+          "name": "pending_payments_token_address_network_tokens_address_network_fk",
+          "tableFrom": "pending_payments",
+          "tableTo": "tokens",
+          "columnsFrom": ["token_address", "network"],
+          "columnsTo": ["address", "network"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_payments_claim_token_unique": {
+          "name": "pending_payments_claim_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["claim_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_settings": {
+      "name": "repo_settings",
+      "schema": "",
+      "columns": {
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "require_owner_approval": {
+          "name": "require_owner_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_owner_user_id": {
+          "name": "verified_owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_repo_settings_owner": {
+          "name": "idx_repo_settings_owner",
+          "columns": [
+            {
+              "expression": "verified_owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_settings_name": {
+          "name": "idx_repo_settings_name",
+          "columns": [
+            {
+              "expression": "github_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_settings_installation": {
+          "name": "idx_repo_settings_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_settings_verified_owner_user_id_user_id_fk": {
+          "name": "repo_settings_verified_owner_user_id_user_id_fk",
+          "tableFrom": "repo_settings",
+          "tableTo": "user",
+          "columnsFrom": ["verified_owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bounty_id": {
+          "name": "bounty_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_pr_id": {
+          "name": "github_pr_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_pr_number": {
+          "name": "github_pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_pr_url": {
+          "name": "github_pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_pr_title": {
+          "name": "github_pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "funder_approved_at": {
+          "name": "funder_approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funder_approved_by": {
+          "name": "funder_approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_approved_at": {
+          "name": "owner_approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_approved_by": {
+          "name": "owner_approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by": {
+          "name": "rejected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_note": {
+          "name": "rejection_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_merged_at": {
+          "name": "pr_merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_closed_at": {
+          "name": "pr_closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_bounty": {
+          "name": "idx_submissions_bounty",
+          "columns": [
+            {
+              "expression": "bounty_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user": {
+          "name": "idx_submissions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_bounty_id_bounties_id_fk": {
+          "name": "submissions_bounty_id_bounties_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "bounties",
+          "columnsFrom": ["bounty_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submissions_user_id_user_id_fk": {
+          "name": "submissions_user_id_user_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submissions_funder_approved_by_user_id_fk": {
+          "name": "submissions_funder_approved_by_user_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "user",
+          "columnsFrom": ["funder_approved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_owner_approved_by_user_id_fk": {
+          "name": "submissions_owner_approved_by_user_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "user",
+          "columnsFrom": ["owner_approved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_rejected_by_user_id_fk": {
+          "name": "submissions_rejected_by_user_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "user",
+          "columnsFrom": ["rejected_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_submissions_unique_pr": {
+          "name": "idx_submissions_unique_pr",
+          "nullsNotDistinct": false,
+          "columns": ["github_pr_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tokens_network_active": {
+          "name": "idx_tokens_network_active",
+          "columns": [
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tokens_address_network_pk": {
+          "name": "tokens_address_network_pk",
+          "columns": ["address", "network"]
+        }
+      },
+      "uniqueConstraints": {
+        "tokens_network_symbol_unique": {
+          "name": "tokens_network_symbol_unique",
+          "nullsNotDistinct": false,
+          "columns": ["network", "symbol"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_key_type": {
+      "name": "access_key_type",
+      "schema": "public",
+      "values": ["secp256k1", "p256", "webauthn"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1766791120313,
       "tag": "0018_nice_leech",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1766852952173,
+      "tag": "0019_romantic_blazing_skull",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/github/app.ts
+++ b/lib/github/app.ts
@@ -1,0 +1,254 @@
+/**
+ * GitHub App Authentication
+ *
+ * Utilities for GitHub App JWT generation, installation tokens, and claim state signing.
+ * Used for the repository claiming flow.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { importPKCS8, SignJWT } from 'jose';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+
+// Installation token cache (in-memory, 55 min TTL to account for clock skew)
+const tokenCache = new Map<string, { token: string; expiresAt: Date }>();
+
+// ============ Types ============
+
+export interface ClaimState {
+  userId: string;
+  owner: string;
+  repo: string;
+  timestamp: number;
+  callbackUrl?: string; // Origin callback URL for dev proxy
+}
+
+export interface InstallationRepo {
+  id: number;
+  node_id: string;
+  name: string;
+  full_name: string;
+  private: boolean;
+  owner: {
+    login: string;
+    id: number;
+  };
+}
+
+// ============ App JWT ============
+
+/**
+ * Generate a JWT for GitHub App authentication
+ *
+ * Used to authenticate as the GitHub App itself (not as an installation).
+ * JWT is signed with RS256 using the App's private key.
+ * Valid for 10 minutes (GitHub's maximum).
+ */
+export async function generateAppJWT(): Promise<string> {
+  const appId = process.env.GITHUB_APP_ID;
+  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+
+  if (!appId || !privateKey) {
+    throw new Error('Missing GITHUB_APP_ID or GITHUB_APP_PRIVATE_KEY environment variables');
+  }
+
+  // Handle escaped newlines in env var
+  const formattedKey = privateKey.replace(/\\n/g, '\n');
+
+  const key = await importPKCS8(formattedKey, 'RS256');
+  const now = Math.floor(Date.now() / 1000);
+
+  return new SignJWT({})
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuedAt(now - 60) // Allow 60s clock skew
+    .setExpirationTime(now + 10 * 60) // 10 min max
+    .setIssuer(appId)
+    .sign(key);
+}
+
+// ============ Installation Tokens ============
+
+/**
+ * Get an installation access token for a GitHub App installation
+ *
+ * Tokens are cached for 55 minutes (they expire after 1 hour).
+ * Used to make API calls on behalf of a specific installation.
+ */
+export async function getInstallationToken(installationId: string | bigint): Promise<string> {
+  const id = installationId.toString();
+  const cached = tokenCache.get(id);
+
+  // Return cached token if still valid (5 min buffer)
+  if (cached && cached.expiresAt > new Date(Date.now() + 5 * 60 * 1000)) {
+    return cached.token;
+  }
+
+  // Get new token from GitHub
+  const appJwt = await generateAppJWT();
+
+  const response = await fetch(`${GITHUB_API_BASE}/app/installations/${id}/access_tokens`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${appJwt}`,
+      Accept: 'application/vnd.github.v3+json',
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error(`[github-app] Failed to get installation token: ${error}`);
+    throw new Error(`Failed to get installation token: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { token: string; expires_at: string };
+
+  // Cache with 55 min TTL (tokens last 1 hour)
+  tokenCache.set(id, {
+    token: data.token,
+    expiresAt: new Date(data.expires_at),
+  });
+
+  return data.token;
+}
+
+/**
+ * Get all repositories accessible to a GitHub App installation
+ */
+export async function getInstallationRepos(
+  installationId: string | bigint
+): Promise<InstallationRepo[]> {
+  const token = await getInstallationToken(installationId);
+
+  const repos: InstallationRepo[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  // Paginate through all repos
+  while (true) {
+    const response = await fetch(
+      `${GITHUB_API_BASE}/installation/repositories?per_page=${perPage}&page=${page}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error(`[github-app] Failed to get installation repos: ${error}`);
+      throw new Error(`Failed to get installation repos: ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      repositories: InstallationRepo[];
+      total_count: number;
+    };
+    repos.push(...data.repositories);
+
+    if (repos.length >= data.total_count) {
+      break;
+    }
+    page++;
+  }
+
+  return repos;
+}
+
+// ============ Claim State Signing ============
+
+const STATE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Sign a claim state for the GitHub App installation flow
+ *
+ * State is base64url encoded and signed with HMAC-SHA256.
+ * Format: {base64url(state)}.{signature}
+ */
+export function signClaimState(state: ClaimState): string {
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    throw new Error('Missing BETTER_AUTH_SECRET environment variable');
+  }
+
+  const data = Buffer.from(JSON.stringify(state)).toString('base64url');
+  const signature = createHmac('sha256', secret).update(data).digest('hex');
+
+  return `${data}.${signature}`;
+}
+
+/**
+ * Verify and decode a signed claim state
+ *
+ * Returns null if:
+ * - Signature is invalid
+ * - State is expired (>10 minutes old)
+ * - State is malformed
+ */
+export function verifyClaimState(signedState: string): ClaimState | null {
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    console.error('[github-app] Missing BETTER_AUTH_SECRET');
+    return null;
+  }
+
+  const parts = signedState.split('.');
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [data, signature] = parts;
+
+  // Verify signature using constant-time comparison
+  const expectedSignature = createHmac('sha256', secret).update(data).digest('hex');
+
+  if (signature.length !== expectedSignature.length) {
+    return null;
+  }
+
+  if (!timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(expectedSignature, 'hex'))) {
+    return null;
+  }
+
+  // Decode and validate state
+  try {
+    const state = JSON.parse(Buffer.from(data, 'base64url').toString()) as ClaimState;
+
+    // Check expiration
+    if (Date.now() - state.timestamp > STATE_EXPIRY_MS) {
+      console.log('[github-app] State expired');
+      return null;
+    }
+
+    // Validate required fields
+    if (!state.userId || !state.owner || !state.repo || !state.timestamp) {
+      return null;
+    }
+
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+// ============ Utility ============
+
+/**
+ * Build the GitHub App installation URL for a specific repository
+ */
+export function getInstallUrl(owner: string, repo: string, state: string): string {
+  const appSlug = process.env.GITHUB_APP_SLUG || 'grip-bounties';
+  const encodedState = encodeURIComponent(state);
+
+  // Suggest installing on specific repo
+  return `https://github.com/apps/${appSlug}/installations/new/permissions?suggested_target_id=${owner}&repository_ids=&state=${encodedState}`;
+}
+
+/**
+ * Build the simple GitHub App installation URL
+ */
+export function getSimpleInstallUrl(state: string): string {
+  const appSlug = process.env.GITHUB_APP_SLUG || 'grip-bounties';
+  return `https://github.com/apps/${appSlug}/installations/new?state=${encodeURIComponent(state)}`;
+}

--- a/lib/github/index.ts
+++ b/lib/github/index.ts
@@ -92,4 +92,5 @@ export async function getGitHubToken(userId: string): Promise<string | null> {
 // ============ Re-exports ============
 
 export * from './api';
+export * from './app';
 export * from './webhooks';

--- a/lib/github/webhooks.ts
+++ b/lib/github/webhooks.ts
@@ -3,7 +3,12 @@ import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 /**
  * GitHub webhook event types we handle
  */
-export type GitHubWebhookEvent = 'pull_request' | 'issues' | 'ping';
+export type GitHubWebhookEvent =
+  | 'pull_request'
+  | 'issues'
+  | 'ping'
+  | 'installation'
+  | 'installation_repositories';
 
 /**
  * Pull request event payload (simplified)
@@ -73,6 +78,48 @@ export interface PingEvent {
     id: number;
     full_name: string;
   };
+}
+
+/**
+ * Installation event (GitHub App installed/uninstalled)
+ */
+export interface InstallationEvent {
+  action: 'created' | 'deleted' | 'suspend' | 'unsuspend' | 'new_permissions_accepted';
+  installation: {
+    id: number;
+    account: {
+      login: string;
+      id: number;
+    };
+  };
+  repositories?: Array<{
+    id: number;
+    full_name: string;
+  }>;
+}
+
+/**
+ * Installation repositories event (repos added/removed from installation)
+ */
+export interface InstallationRepositoriesEvent {
+  action: 'added' | 'removed';
+  installation: {
+    id: number;
+    account: {
+      login: string;
+      id: number;
+    };
+  };
+  repositories_added?: Array<{
+    id: number;
+    full_name: string;
+    private: boolean;
+  }>;
+  repositories_removed?: Array<{
+    id: number;
+    full_name: string;
+    private: boolean;
+  }>;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "drizzle-orm": "^0.38.3",
+    "jose": "^6.1.3",
     "lucide-react": "^0.469.0",
     "next": "^15.2.7",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   drizzle-orm:
     specifier: ^0.38.3
     version: 0.38.4(@types/react@19.2.7)(kysely@0.28.8)(postgres@3.4.7)(react@19.2.1)
+  jose:
+    specifier: ^6.1.3
+    version: 6.1.3
   lucide-react:
     specifier: ^0.469.0
     version: 0.469.0(react@19.2.1)


### PR DESCRIPTION
Replace OAuth-based claiming with GitHub App installation flow:
- Add GitHub App JWT generation and installation token caching
- Add signed claim state with HMAC-SHA256 for secure callbacks
- Add claim initiation endpoint at /api/repos/[owner]/[repo]/claim
- Add callback handler at /api/github/callback with dev proxy support
- Add installationId column to repo_settings schema
- Update webhook handler for installation events
- Fix RepoStatsCard to trigger claim flow instead of linking to settings
- Update settings page to show ClaimRepoCard when repo unclaimed

Dev proxy allows local development by forwarding callbacks from production to localhost (restricted to localhost/127.0.0.1 only).